### PR TITLE
Add customizable themes via console

### DIFF
--- a/public/js/inspector.js
+++ b/public/js/inspector.js
@@ -175,21 +175,12 @@
 
     TiInspector.loadInspector = function loadInspector() {
 
-         function loadCssInIframe(url) {
-             if (!url) {
-                 return;
-             }
-
-             var iframe = document.getElementById("devtools-frame");
-             $(iframe.contentDocument.head).append('<link rel="stylesheet" type="text/css" href="' + url +'">');
-         }
-
+        if (TiInspector.preferences) {
+            TiInspector.preferences.styles = StylesConfig.getInstance();
+        }
 
         $('#devtools-frame').load(function() {
-            if (TiInspector.preferences) {
-                loadCssInIframe(TiInspector.preferences.devtools_theme);
-            }
-            loadCssInIframe('/css/inspector-overrides.css');
+            TiInspector.preferences.styles.save();
         });
 
         var sessionId = window.location.hash.replace('#', '');

--- a/public/js/inspector.js
+++ b/public/js/inspector.js
@@ -114,16 +114,14 @@
     };
 
     // Instance methods {{{2
-    // StylesConfig::save {{{3
-    // Will save the list to localStorage and push new styles into the
-    // #devtools-frame head. It will only add links for styles marked as not
-    // saved (to prevent duplicates and avoid needless DOM queries. It uses a
-    // nextTick to defer DOM manipulations.
-    StylesConfig.prototype.save = function() {
+    // StylesConfig::link {{{3
+    // Will push new styles into the #devtools-frame head. It will only add
+    // links for styles marked as not saved (to prevent duplicates and avoid
+    // needless DOM queries. It uses a nextTick to defer DOM manipulations.
+    StylesConfig.prototype.link = function() {
         if (!this.pending) {
             this.pending = setTimeout(savePendingStyles_.bind(this), 0);
         }
-        setSavedStyles(this.styles);
         return this;
     };
 
@@ -131,7 +129,8 @@
     StylesConfig.prototype.add = function(url) {
         if (!url) { return; }
         this.styles.push({url: url});
-        return this;
+        setSavedStyles(this.styles);
+        return this.link();
     };
 
     // StylesConfig::remove {{{3
@@ -143,6 +142,7 @@
             this.styles.splice(index, 1);
             removeStyleLink(index);
         }
+        setSavedStyles(this.styles);
         return this;
     };
 

--- a/public/js/inspector.js
+++ b/public/js/inspector.js
@@ -155,7 +155,15 @@
         return this;
     };
 
-    // StylesConfig::toString {{{3
+    // StylesConfig::clear {{{3
+    StylesConfig.prototype.clear = function() {
+        this.unlinkAll();
+        this.styles = [];
+        setSavedStyles(this.styles);
+        return this;
+    };
+
+    // StylesConfig:toString {{{3
     StylesConfig.prototype.toString = function() {
         var styleUrls = this.styles.map(function(style) {
             return '' + style.url + (style.saved ? '' : ' (*)');

--- a/public/js/inspector.js
+++ b/public/js/inspector.js
@@ -2,16 +2,187 @@
     /* jshint boss:true */
     'use strict';
 
+    var style_id_prefix     = 'ti-inspector-style-';
+    var style_storage_id    = style_id_prefix + 'perfs';
+    var style_overrides_id  = style_id_prefix + 'override';
+    var style_overrides_url = '/css/inspector-overrides.css';
+    var styles_config_instance;
+
+    // StylesConfig Class {{{1
+    // Constructor {{{2
+    // Will add devtools_theme as the default if it exists and localStorage is
+    // empty.
+    function StylesConfig() {
+        this.styles = getSavedStyles();
+        if (TiInspector.preferences && this.styles.length === 0) {
+            this.add(TiInspector.preferences.devtools_theme);
+        }
+    }
+
+    // Private Methods {{{2
+    // getSavedStyles {{{3
+    var getSavedStyles = function() {
+        var urls = (JSON.parse(
+            localStorage.getItem(style_storage_id)
+        ) || []);
+        return urls.map(function(url) {
+            return {url: url};
+        });
+    };
+
+    // setSavedStyles {{{3
+    var setSavedStyles = function(styles) {
+        styles = styles.map(function(style) {
+            return style.url;
+        });
+        localStorage.setItem(
+            style_storage_id,
+            JSON.stringify(styles)
+        );
+    };
+
+    // idFromIndex {{{3
+    var idFromIndex = function(index) {
+        return style_id_prefix + index;
+    };
+
+    // getFrameDoc {{{3
+    var getFrameDoc = function() {
+        var iframe = document.getElementById('devtools-frame');
+        return iframe.contentDocument;
+    };
+
+    // getStylesConfigLink {{{3
+    var getStylesConfigLink = function(index) {
+        return getFrameDoc().getElementById(idFromIndex(index));
+    };
+
+    // makeLinkTag {{{3
+    var makeLinkTag = function(id, url) {
+        var link = document.createElement('link');
+        link.setAttribute('id',   id);
+        link.setAttribute('rel',  'stylesheet');
+        link.setAttribute('type', 'text/css');
+        link.setAttribute('href', url);
+        return link;
+    };
+
+    // insertOverrideStyle {{{3
+    var insertOverrideStyle = function() {
+        var iframe = getFrameDoc();
+        var overrideLink = makeLinkTag(
+            style_overrides_id,
+            style_overrides_url
+        );
+        iframe.head.appendChild(overrideLink);
+        return overrideLink;
+    };
+
+    // appendStyleLink {{{3
+    var appendStyleLink = function(url, index) {
+        var id     = idFromIndex(index);
+        var iframe = getFrameDoc();
+        var link   = makeLinkTag(id, url);
+        var overrideLink = (
+            iframe.getElementById(style_overrides_id) ||
+            insertOverrideStyle()
+        );
+        iframe.head.insertBefore(link, overrideLink);
+        link = iframe = overrideLink = null;
+        return id;
+    };
+
+    // savePendingStyles_ {{{3
+    // Meant to be used as a private instance method (set context with bind)
+    var savePendingStyles_ = function() {
+        this.pending = null;
+        this.styles.forEach(function(style, index) {
+            if (!style.saved) {
+                appendStyleLink(style.url, index);
+                style.saved = true;
+            }
+        });
+    };
+
+    // removeStyleLink {{{3
+    var removeStyleLink = function(index) {
+        var link = getStylesConfigLink(index);
+        if (link && link.parentNode) {
+            link.parentNode.removeChild(link);
+        }
+        return link;
+    };
+
+    // Instance methods {{{2
+    // StylesConfig::save {{{3
+    // Will save the list to localStorage and push new styles into the
+    // #devtools-frame head. It will only add links for styles marked as not
+    // saved (to prevent duplicates and avoid needless DOM queries. It uses a
+    // nextTick to defer DOM manipulations.
+    StylesConfig.prototype.save = function() {
+        if (!this.pending) {
+            this.pending = setTimeout(savePendingStyles_.bind(this), 0);
+        }
+        setSavedStyles(this.styles);
+        return this;
+    };
+
+    // StylesConfig::add {{{3
+    StylesConfig.prototype.add = function(url) {
+        if (!url) { return; }
+        this.styles.push({url: url});
+        return this;
+    };
+
+    // StylesConfig::remove {{{3
+    StylesConfig.prototype.remove = function(url) {
+        var index = this.styles
+          .map(function(style) { return style.url; })
+          .indexOf(url);
+        if (index >= 0) {
+            this.styles.splice(index, 1);
+            removeStyleLink(index);
+        }
+        return this;
+    };
+
+    // StylesConfig::unlinkAll {{{3
+    StylesConfig.prototype.unlinkAll = function() {
+        this.styles.forEach(function(style, index) {
+            removeStyleLink(index);
+            style.saved = false;
+        });
+        return this;
+    };
+
+    // StylesConfig::toString {{{3
+    StylesConfig.prototype.toString = function() {
+        var styleUrls = this.styles.map(function(style) {
+            return '' + style.url + (style.saved ? '' : ' (*)');
+        }).join(', ');
+        return 'StylesConfig: [' + (styleUrls || 'No styles configured') + ']';
+    };
+
+    // Class Methods {{{2
+    // StylesConfig.getInstance {{{3
+    StylesConfig.getInstance = function() {
+        if (!styles_config_instance) {
+            styles_config_instance = new StylesConfig();
+        }
+        return styles_config_instance;
+    };
+    // }}}1
 
     TiInspector.loadInspector = function loadInspector() {
 
-        function loadCssInIframe(url) {
-            if (!url) {
-                return;
-            }
-            var iframe = document.getElementById("devtools-frame");
-            $(iframe.contentDocument.head).append('<link rel="stylesheet" type="text/css" href="' + url +'">');
-        };
+         function loadCssInIframe(url) {
+             if (!url) {
+                 return;
+             }
+
+             var iframe = document.getElementById("devtools-frame");
+             $(iframe.contentDocument.head).append('<link rel="stylesheet" type="text/css" href="' + url +'">');
+         }
 
 
         $('#devtools-frame').load(function() {

--- a/public/js/inspector.js
+++ b/public/js/inspector.js
@@ -1,7 +1,6 @@
-(function() {
-    if (typeof TiInspector == "undefined") {
-        TiInspector = {};
-    }
+(function(TiInspector) {
+    /* jshint boss:true */
+    'use strict';
 
 
     TiInspector.loadInspector = function loadInspector() {
@@ -70,6 +69,7 @@
         ws.onclose = function() {
             changeWindowUrl(null);
         };
-    }
+    };
 
-}())
+})(TiInspector || (TiInspector = {}));
+/* vim:set ts=4 sw=4 et fdm=marker: */


### PR DESCRIPTION
Since a theme is nothing more then a CSS file linked into the iframe this pull request offers a `StylesConfig` object to manage a list of user defined CSS. Either through the `devtools_theme` when the user first uses the application or manually as the user adds or removes CSS URLs. The preferences are save to `localStorage` for future use.

When the application loads it will attach an instance of `StylesConfig` to `TiInspector.preferences.styles` which has the following methods:

| Method | Description |
| --- | --- |
| add | Adds a CSS URL to the user's preferred CSS list. |
| remove | Removes a URL from the list. |
| clear | Remove all custom CSS from the list. |
| link | Will add each CSS URL to the `<head>` with `<link>` tags. |
| unlinkAll | Will remove all the associated `<link>` tags. |
| toString | Display the current state of the list. `(*)` means hasn't been saved (`appendChild`) to the page yet. |

All the above methods are chainable. Internally this is a singleton class which can be grabbed with `StylesConfig.getInstance()`.

Usage would be to open the console `Command-Option-J` while debugging a session and manipulate `TiInspector.preferences.styles`:

```
> TiInspector.preferences.styles.add('http://mysite.com/mytheme.css').save();
> TiInspector.preferences.styles.remove('http://mysite.com/mytheme.css').save();
> TiInspector.preferences.styles.add('/themes/cobalt.css').save();
> TiInspector.preferences.styles.add('/themes/foo.css'); // No .save()
> TiInspector.preferences.styles.toString();
StylesConfig: [/themes/cobalt.css, /themes/foo.css (*)]
```

Order of precedence is preserved (including the `inspector-overrides.css` as last). Further manipulation can be done by mutating the underlying array manually with `this.styles` which is an array of objects that have a `url` property. The `saved` property is an internal flag managed automatically.
